### PR TITLE
Add web seed support to magnet_link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ unicode-normalization = "0.1.8"
 conv = "0.3.3"
 sha-1 = "0.8.2"
 error-chain = "0.12.1"
+percent-encoding = "2.1.0"
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
 
 extern crate conv;
 extern crate itertools;
+extern crate percent_encoding;
 extern crate sha1;
 extern crate unicode_normalization;
 #[macro_use]

--- a/src/torrent/v1/mod.rs
+++ b/src/torrent/v1/mod.rs
@@ -512,6 +512,80 @@ mod torrent_tests {
     }
 
     #[test]
+    fn magnet_link_with_web_seed() {
+        let torrent = Torrent {
+            announce: None,
+            announce_list: None,
+            length: 4,
+            files: None,
+            name: "sample".to_owned(),
+            piece_length: 2,
+            pieces: vec![vec![1, 2], vec![3, 4]],
+            extra_fields: Some(HashMap::from([
+                ("url-list".to_owned(), BencodeElem::String("https://example.org/path".to_owned()))
+            ])),
+            extra_info_fields: None,
+        };
+
+        assert_eq!(
+            torrent.magnet_link(),
+            "magnet:?xt=urn:btih:074f42efaf8267f137f114f722d4e7d1dcbfbda5\
+             &dn=sample&ws=https://example.org/path"
+                .to_owned()
+        );
+    }
+
+    #[test]
+    fn magnet_link_with_web_seeds() {
+        let torrent = Torrent {
+            announce: None,
+            announce_list: None,
+            length: 4,
+            files: None,
+            name: "sample".to_owned(),
+            piece_length: 2,
+            pieces: vec![vec![1, 2], vec![3, 4]],
+            extra_fields: Some(HashMap::from([("url-list".to_owned(), BencodeElem::List(vec![
+                BencodeElem::String("https://example.org/path1".to_owned()),
+                BencodeElem::String("https://example.org/path2".to_owned()),
+            ]))])),
+            extra_info_fields: None,
+        };
+
+        assert_eq!(
+            torrent.magnet_link(),
+            "magnet:?xt=urn:btih:074f42efaf8267f137f114f722d4e7d1dcbfbda5\
+             &dn=sample&ws=https://example.org/path1&ws=https://example.org/path2"
+                .to_owned()
+        );
+    }
+
+    #[test]
+    fn magnet_link_escape() {
+        let torrent = Torrent {
+            announce: Some("https://example.org/path?a=1&b=hello world".to_owned()),
+            announce_list: None,
+            length: 4,
+            files: None,
+            name: "sample".to_owned(),
+            piece_length: 2,
+            pieces: vec![vec![1, 2], vec![3, 4]],
+            extra_fields: Some(HashMap::from([
+                ("url-list".to_owned(), BencodeElem::String("https://example.org/path?a=1&b=hello world".to_owned()))
+            ])),
+            extra_info_fields: None,
+        };
+
+        assert_eq!(
+            torrent.magnet_link(),
+            "magnet:?xt=urn:btih:074f42efaf8267f137f114f722d4e7d1dcbfbda5\
+             &dn=sample&tr=https://example.org/path?a=1%26b=hello%20world\
+             &ws=https://example.org/path?a=1%26b=hello%20world"
+                .to_owned()
+        );
+    }
+
+    #[test]
     fn is_private_ok() {
         let torrent = Torrent {
             announce: Some("url".to_owned()),


### PR DESCRIPTION
I just translated the `url-list` field to appropriate `ws` parameters.

to do:

* [x] tests
* [x] urlencode the urls. (`&` characters at least)
  * [x] looks like trackers aren't urlencoded either. check that.
* [x] test how torrent clients behave with escaped magnet links, since there's no spec for that
  * qbittorrent accepts the escaped trackers, but does not accept web seeds... is it a bug in qbittorrent or in my patch?
  * same for deluge
  * is there _any_ client that supports web seeds in magnet links?