### PR TITLE
Replace `error-chain` with `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.10.3"
 unicode-normalization = "0.1.8"
 conv = "0.3.3"
 sha-1 = "0.10.0"
-error-chain = "0.12.1"
+thiserror = "1.0.30"
 percent-encoding = "2.1.0"
 
 [dev-dependencies]

--- a/src/bencode/write.rs
+++ b/src/bencode/write.rs
@@ -1,14 +1,14 @@
 //! Module for bencode-related encoding.
 
 use super::*;
-use error::*;
 use std::fs::File;
 use std::hash::BuildHasher;
 use std::io::{BufWriter, Write};
 use std::path::Path;
+use LavaTorrentError;
 
 /// Encode `string` and write the result to `dst`.
-pub fn write_string<S, W>(string: S, dst: &mut W) -> Result<()>
+pub fn write_string<S, W>(string: S, dst: &mut W) -> Result<(), LavaTorrentError>
 where
     S: AsRef<str>,
     W: Write,
@@ -21,7 +21,7 @@ where
 }
 
 /// Encode `bytes` and write the result to `dst`.
-pub fn write_bytes<B, W>(bytes: B, dst: &mut W) -> Result<()>
+pub fn write_bytes<B, W>(bytes: B, dst: &mut W) -> Result<(), LavaTorrentError>
 where
     B: AsRef<[u8]>,
     W: Write,
@@ -34,7 +34,7 @@ where
 }
 
 /// Encode `int` and write the result to `dst`.
-pub fn write_integer<W>(int: i64, dst: &mut W) -> Result<()>
+pub fn write_integer<W>(int: i64, dst: &mut W) -> Result<(), LavaTorrentError>
 where
     W: Write,
 {
@@ -45,7 +45,7 @@ where
 }
 
 /// Encode `list` and write the result to `dst`.
-pub fn write_list<L, W>(list: L, dst: &mut W) -> Result<()>
+pub fn write_list<L, W>(list: L, dst: &mut W) -> Result<(), LavaTorrentError>
 where
     L: AsRef<[BencodeElem]>,
     W: Write,
@@ -60,7 +60,10 @@ where
 }
 
 /// Encode `dict` and write the result to `dst`.
-pub fn write_dictionary<W, S>(dict: &HashMap<String, BencodeElem, S>, dst: &mut W) -> Result<()>
+pub fn write_dictionary<W, S>(
+    dict: &HashMap<String, BencodeElem, S>,
+    dst: &mut W,
+) -> Result<(), LavaTorrentError>
 where
     W: Write,
     S: BuildHasher,
@@ -83,7 +86,7 @@ where
 pub fn write_raw_dictionary<W, S>(
     dict: &HashMap<Vec<u8>, BencodeElem, S>,
     dst: &mut W,
-) -> Result<()>
+) -> Result<(), LavaTorrentError>
 where
     W: Write,
     S: BuildHasher,
@@ -163,7 +166,7 @@ where
 
 impl BencodeElem {
     /// Encode `self` and write the result to `dst`.
-    pub fn write_into<W>(&self, dst: &mut W) -> Result<()>
+    pub fn write_into<W>(&self, dst: &mut W) -> Result<(), LavaTorrentError>
     where
         W: Write,
     {
@@ -187,7 +190,7 @@ impl BencodeElem {
     /// Note: it is the client's responsibility to ensure
     /// that all directories in `path` actually exist (e.g.
     /// by calling [`create_dir_all`](https://doc.rust-lang.org/std/fs/fn.create_dir_all.html)).
-    pub fn write_into_file<P>(&self, path: P) -> Result<()>
+    pub fn write_into_file<P>(&self, path: P) -> Result<(), LavaTorrentError>
     where
         P: AsRef<Path>,
     {

--- a/src/torrent/v1/write.rs
+++ b/src/torrent/v1/write.rs
@@ -1,6 +1,7 @@
 use super::*;
 use bencode::BencodeElem;
 use std::io::{BufWriter, Write};
+use LavaTorrentError;
 
 impl File {
     pub(crate) fn into_bencode_elem(self) -> BencodeElem {
@@ -27,7 +28,7 @@ impl File {
 
 impl Torrent {
     /// Encode `self` as bencode and write the result to `dst`.
-    pub fn write_into<W>(self, dst: &mut W) -> Result<()>
+    pub fn write_into<W>(self, dst: &mut W) -> Result<(), LavaTorrentError>
     where
         W: Write,
     {
@@ -102,7 +103,7 @@ impl Torrent {
     /// Note: it is the client's responsibility to ensure
     /// that all directories in `path` actually exist (e.g.
     /// by calling [`create_dir_all`](https://doc.rust-lang.org/std/fs/fn.create_dir_all.html)).
-    pub fn write_into_file<P>(self, path: P) -> Result<()>
+    pub fn write_into_file<P>(self, path: P) -> Result<(), LavaTorrentError>
     where
         P: AsRef<Path>,
     {
@@ -113,7 +114,7 @@ impl Torrent {
     }
 
     /// Encode `self` as bencode and return the result in a `Vec`.
-    pub fn encode(self) -> Result<Vec<u8>> {
+    pub fn encode(self) -> Result<Vec<u8>, LavaTorrentError> {
         let mut result = Vec::new();
         self.write_into(&mut result)?;
         Ok(result)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,35 +1,41 @@
-use error::*;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
+use LavaTorrentError;
 
-pub(crate) fn u64_to_usize(src: u64) -> Result<usize> {
-    usize::try_from(src).chain_err(|| {
-        ErrorKind::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into usize.", src)))
+pub(crate) fn u64_to_usize(src: u64) -> Result<usize, LavaTorrentError> {
+    usize::try_from(src).map_err(|_| {
+        LavaTorrentError::FailedNumericConv(Cow::Owned(format!(
+            "[{}] does not fit into usize.",
+            src
+        )))
     })
 }
 
-pub(crate) fn usize_to_u64(src: usize) -> Result<u64> {
-    u64::try_from(src).chain_err(|| {
-        ErrorKind::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into u64.", src)))
+pub(crate) fn usize_to_u64(src: usize) -> Result<u64, LavaTorrentError> {
+    u64::try_from(src).map_err(|_| {
+        LavaTorrentError::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into u64.", src)))
     })
 }
 
-pub(crate) fn i64_to_usize(src: i64) -> Result<usize> {
-    usize::try_from(src).chain_err(|| {
-        ErrorKind::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into usize.", src)))
+pub(crate) fn i64_to_usize(src: i64) -> Result<usize, LavaTorrentError> {
+    usize::try_from(src).map_err(|_| {
+        LavaTorrentError::FailedNumericConv(Cow::Owned(format!(
+            "[{}] does not fit into usize.",
+            src
+        )))
     })
 }
 
-pub(crate) fn i64_to_u64(src: i64) -> Result<u64> {
-    u64::try_from(src).chain_err(|| {
-        ErrorKind::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into u64.", src)))
+pub(crate) fn i64_to_u64(src: i64) -> Result<u64, LavaTorrentError> {
+    u64::try_from(src).map_err(|_| {
+        LavaTorrentError::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into u64.", src)))
     })
 }
 
-pub(crate) fn u64_to_i64(src: u64) -> Result<i64> {
-    i64::try_from(src).chain_err(|| {
-        ErrorKind::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into i64.", src)))
+pub(crate) fn u64_to_i64(src: u64) -> Result<i64, LavaTorrentError> {
+    i64::try_from(src).map_err(|_| {
+        LavaTorrentError::FailedNumericConv(Cow::Owned(format!("[{}] does not fit into i64.", src)))
     })
 }
 
@@ -39,7 +45,7 @@ pub(crate) fn u64_to_i64(src: u64) -> Result<i64> {
 // *nix hidden files/dirs are ignored
 //
 // returned vec is sorted by path
-pub(crate) fn list_dir<P>(path: P) -> Result<Vec<(PathBuf, u64)>>
+pub(crate) fn list_dir<P>(path: P) -> Result<Vec<(PathBuf, u64)>, LavaTorrentError>
 where
     P: AsRef<Path>,
 {
@@ -65,14 +71,14 @@ where
     Ok(entries)
 }
 
-pub(crate) fn last_component<P>(path: P) -> Result<String>
+pub(crate) fn last_component<P>(path: P) -> Result<String, LavaTorrentError>
 where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
     match path.file_name() {
         Some(s) => Ok(s.to_string_lossy().into_owned()),
-        None => bail!(ErrorKind::InvalidArgument(Cow::Owned(format!(
+        None => Err(LavaTorrentError::InvalidArgument(Cow::Owned(format!(
             r#"[{}] ends in ".."."#,
             path.display()
         )))),
@@ -187,7 +193,7 @@ mod util_tests {
     #[test]
     fn last_component_err() {
         match last_component("/root/dir/..") {
-            Err(Error(ErrorKind::InvalidArgument(m), _)) => {
+            Err(LavaTorrentError::InvalidArgument(m)) => {
                 assert_eq!(m, r#"[/root/dir/..] ends in ".."."#,);
             }
             _ => assert!(false),
@@ -214,7 +220,7 @@ mod util_tests {
     #[test]
     fn i64_to_usize_err() {
         match i64_to_usize(-1) {
-            Err(Error(ErrorKind::FailedNumericConv(m), _)) => {
+            Err(LavaTorrentError::FailedNumericConv(m)) => {
                 assert_eq!(m, "[-1] does not fit into usize.");
             }
             _ => assert!(false),
@@ -229,7 +235,7 @@ mod util_tests {
     #[test]
     fn i64_to_u64_err() {
         match i64_to_u64(-1) {
-            Err(Error(ErrorKind::FailedNumericConv(m), _)) => {
+            Err(LavaTorrentError::FailedNumericConv(m)) => {
                 assert_eq!(m, "[-1] does not fit into u64.");
             }
             _ => assert!(false),
@@ -244,7 +250,7 @@ mod util_tests {
     #[test]
     fn u64_to_i64_err() {
         match u64_to_i64(u64::max_value()) {
-            Err(Error(ErrorKind::FailedNumericConv(m), _)) => {
+            Err(LavaTorrentError::FailedNumericConv(m)) => {
                 assert_eq!(m, format!("[{}] does not fit into i64.", u64::max_value()))
             }
             _ => assert!(false),


### PR DESCRIPTION
The `error-chain` crate has been deprecated, so I replaced it with `thiserror`.

I ran `cargo test` and all the tests pass, except the `build_*` ones, but those don't pass even on the main branch (on my end).